### PR TITLE
fix build script for macos

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ demo page can be found at http://node.ispol.sk
 - transaction explorer - details about a TX are shown once the hash is included in the search bar
 ![transactionexplorer screenshot](doc/img/txexplorer.png "Transactionexplorer")
 
-# docker setup (Linux):
+# docker setup (Linux/macOS):
  - download [bitcoin-core](https://bitcoin.org/en/download)
  - install docker
  - clone this repo:

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -37,7 +37,12 @@ case "$answer" in
 esac
 echo "configuring for $network"
 
-config=$(echo ${conf_template}|sed -r 's/_network_/'"$network"'/')
+# For macOS, use `sed -E`
+if [ "$(uname)" == "Darwin" ]; then
+	config=$(echo ${conf_template}|sed -E 's/_network_/'"$network"'/')
+else
+	config=$(echo ${conf_template}|sed -r 's/_network_/'"$network"'/')
+fi
 
 echo "running docker for you"
 set -x


### PR DESCRIPTION
Fixes `sed` command running on `macOS`. Option `-r` is substituted for `-E`.
https://stackoverflow.com/questions/43696304/how-do-i-fix-sed-illegal-option-r-in-macos-sierra-android-build#comment74464777_43696304